### PR TITLE
Added config for printing to console

### DIFF
--- a/__resource.lua
+++ b/__resource.lua
@@ -1,5 +1,9 @@
-description "ELS FiveM" -- Resource Descrption
-resource_manifest_version "44febabe-d386-4d18-afbe-5e627f4af937"
+resource_manifest_version '44febabe-d386-4d18-afbe-5e627f4af937'
+
+description 'ELS FiveM'
+
+version '1.7'
+
 client_script {
 	'vcf.lua',
 	'config.lua',
@@ -8,12 +12,12 @@ client_script {
 	'client/_patternTypes/leds.lua',
 	'client/_patternTypes/traf.lua',
 	'client/_patternTypes/chp.lua',
-	'client/patterns.lua',
+	'client/patterns.lua'
 }
 
 server_script {
 	'vcf.lua',
 	'config.lua',
 	'server/server.lua',
-	'server/xml.lua',
+	'server/xml.lua'
 }

--- a/config.lua
+++ b/config.lua
@@ -1,5 +1,6 @@
 outputLoading = false
 playButtonPressSounds = true
+printDebugInformation = false
 
 vehicleSyncDistance = 150
 envirementLightBrightness = 0.005

--- a/config.lua
+++ b/config.lua
@@ -1,6 +1,6 @@
 outputLoading = false
 playButtonPressSounds = true
-printDebugInformation = false
+printDebugInformation = true
 
 vehicleSyncDistance = 150
 envirementLightBrightness = 0.005

--- a/server/server.lua
+++ b/server/server.lua
@@ -370,9 +370,9 @@ function parseVehData(xml, fileName)
 
     vehicleInfoTable[fileName] = a
 
-    if outputLoading and outputLoading ~= nil then
-    	print("Done with vehicle: " .. fileName)
-    end
+	if outputLoading and outputLoading ~= nil and printDebugInformation then
+		print("Done with vehicle: " .. fileName)
+	end
 end
 
 function parsePatternData(xml, fileName)
@@ -625,9 +625,9 @@ function parsePatternData(xml, fileName)
     end
     patternInfoTable[#patternInfoTable + 1] = a
 
-    if outputLoading and outputLoading ~= nil then
-    	print("Done with pattern: " .. fileName)
-    end
+	if outputLoading and outputLoading ~= nil and printDebugInformation then
+		print("Done with pattern: " .. fileName)
+	end
 end
 
 function parseObjSet(data, fileName)
@@ -676,7 +676,10 @@ end)
 
 RegisterServerEvent("els:requestVehiclesUpdate")
 AddEventHandler('els:requestVehiclesUpdate', function()
-	print("Sending player (" .. source .. ") ELS data")
+	if printDebugInformation then
+		print("Sending player (" .. source .. ") ELS data")
+	end
+
 	TriggerClientEvent("els:updateElsVehicles", source, vehicleInfoTable, patternInfoTable)
 end)
 

--- a/server/server.lua
+++ b/server/server.lua
@@ -370,8 +370,10 @@ function parseVehData(xml, fileName)
 
     vehicleInfoTable[fileName] = a
 
-	if outputLoading and outputLoading ~= nil and printDebugInformation then
-		print("Done with vehicle: " .. fileName)
+	if outputLoading and outputLoading ~= nil then
+		if printDebugInformation == nil or printDebugInformation == true then
+			print("Done with vehicle: " .. fileName)
+		end
 	end
 end
 
@@ -625,8 +627,10 @@ function parsePatternData(xml, fileName)
     end
     patternInfoTable[#patternInfoTable + 1] = a
 
-	if outputLoading and outputLoading ~= nil and printDebugInformation then
-		print("Done with pattern: " .. fileName)
+	if outputLoading and outputLoading ~= nil then
+		if printDebugInformation == nil or printDebugInformation == true then
+			print("Done with pattern: " .. fileName)
+		end
 	end
 end
 
@@ -676,7 +680,7 @@ end)
 
 RegisterServerEvent("els:requestVehiclesUpdate")
 AddEventHandler('els:requestVehiclesUpdate', function()
-	if printDebugInformation then
+	if printDebugInformation == nil or printDebugInformation == true then
 		print("Sending player (" .. source .. ") ELS data")
 	end
 


### PR DESCRIPTION
- The 'Sending player ELS data' prints are no longer printed on default, and has been moved to a configuration option.
- Minor cleanup to the resource manifest, having the manifest version at the very top and added the `version` variable.